### PR TITLE
support to call from package name

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,15 @@ class ConcatPlugin {
         let content = '';
         const concatPromise = self.settings.filesToConcat.map(fileName =>
             new Promise((resolve, reject) => {
+                if (!fileName.match(/^(\.|\/)/) && fs.lstatSync('./node_modules/' + fileName.split('/')[0]).isDirectory()) {
+                    let packageFile = './node_modules/' + fileName;
+                    if (fileName.includes('/')) {
+                        fileName = packageFile + '.js';
+                    }
+                    else {
+                        fileName = packageFile + '/' + JSON.parse(fs.readFileSync(path.resolve(packageFile + '/package.json')).toString()).main;
+                    }
+                }
                 fs.readFile(fileName, (err, data) => {
                     if (err) {
                         throw err;

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class ConcatPlugin {
                     }
                     else {
                         fileName = packageFile + '/' + JSON.parse(fs.readFileSync(path.resolve(packageFile + '/package.json')).toString()).main;
-                        if (!fileName.includes('.js')) fileName += '.js';
+                        if (!fileName.endsWith('.js')) fileName += '.js';
                     }
                 }
                 fs.readFile(fileName, (err, data) => {

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ class ConcatPlugin {
                     }
                     else {
                         fileName = packageFile + '/' + JSON.parse(fs.readFileSync(path.resolve(packageFile + '/package.json')).toString()).main;
+                        if (!fileName.includes('.js')) fileName += '.js';
                     }
                 }
                 fs.readFile(fileName, (err, data) => {


### PR DESCRIPTION
Call main file using the package name

Ex:
```js
plugins: [
    new ConcatPlugin({
    ...
        filesToConcat: [
            'jquery',
            'bootstrap',
            'smooth-scrollbar',
            'isotope-layout',
        ]
    })
]
```