### PR TITLE
Use uglify-es to support es2015 and above

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * @author huangxueliang
  */
 const fs = require('fs');
-const UglifyJS = require('uglify-js');
+const UglifyJS = require('uglify-es');
 const md5 = require('md5');
 const path = require('path');
 
@@ -83,19 +83,23 @@ class ConcatPlugin {
                 self.settings.fileName = self.getFileName(allFiles);
 
                 if (process.env.NODE_ENV === 'production' || self.settings.uglify) {
-                    let options = {
-                        fromString: true
-                    };
+                    let options = {};
 
                     if (typeof self.settings.uglify === 'object') {
                         options = Object.assign({}, self.settings.uglify, options);
                     }
 
                     if (self.settings.sourceMap) {
-                        options.outSourceMap = `${self.settings.fileName.split(path.sep).slice(-1).join(path.sep)}.map`;
+                        options.sourceMap = {
+                            filename: `${self.settings.fileName.split(path.sep).slice(-1).join(path.sep)}.map`
+                        }
                     }
 
                     const result = UglifyJS.minify(allFiles, options);
+
+                    if (result.error) {
+                        throw result.error;
+                    }
 
                     content = result.code;
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/hxlniada/webpack-concat-plugin#readme",
   "dependencies": {
     "md5": "^2.2.1",
-    "uglify-js": "^2.8.29"
+    "uglify-es": "^3.2.1"
   }
 }


### PR DESCRIPTION
Hi hxlniada!

This PR is related to [issue](https://github.com/angular/angular-cli/issues/8561) in `angular-cli` repo.

**tldr:** support for minification of code which uses es2015 and above

This could in theory be breaking change because there are API differences between uglify 2.x vs 3.x. 
The support for passing additional uglify options (which now might look different) was added previously  by @filipesilva . So I guess the major release would be needed, or please let me know about your opinion on this matter.

Cheers,
Tomas