### PR TITLE
updates for new hooks in html-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "html-webpack-plugin": "^3.0.4",
+    "html-webpack-plugin": "^4.0.0-beta.4",
     "is-object": "^1.0.1",
     "jest": "^22.4.2",
     "webpack": "^4.0.1"

--- a/test/cases/html-plugin-auto-inject/webpack.config.js
+++ b/test/cases/html-plugin-auto-inject/webpack.config.js
@@ -4,7 +4,17 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 module.exports = {
     entry: './index.js',
     plugins: [
-        new HtmlWebpackPlugin({ template: './index.ejs' }),
+        new HtmlWebpackPlugin({
+            template: './index.ejs',
+            minify: {
+                collapseWhitespace: false,
+                removeComments: true,
+                removeRedundantAttributes: false,
+                removeScriptTypeAttributes: false,
+                removeStyleLinkTypeAttributes: false,
+                useShortDoctype: false
+            }
+        }),
         new ConcatPlugin({
             uglify: true,
             sourceMap: true,

--- a/test/cases/html-plugin/webpack.config.js
+++ b/test/cases/html-plugin/webpack.config.js
@@ -4,7 +4,17 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 module.exports = {
     entry: './index.js',
     plugins: [
-        new HtmlWebpackPlugin({ template: './index.ejs' }),
+        new HtmlWebpackPlugin({
+            template: './index.ejs',
+            minify: {
+                collapseWhitespace: false,
+                removeComments: true,
+                removeRedundantAttributes: false,
+                removeScriptTypeAttributes: false,
+                removeStyleLinkTypeAttributes: false,
+                useShortDoctype: false
+            }
+        }),
         new ConcatPlugin({
             uglify: true,
             sourceMap: true,


### PR DESCRIPTION
I ran into this issue today after upgrading to the next version of weback-html-plugin.
#61

i left the old compiler options, this should be backwards compatible as i ran it with both versions of htmlWebpackPlugin, only the local decency version of webpack has to be the latest for this to work i guess, if that is true then the backwards compatibility will most likely not work.

Im not really sure if this will actually work unless the local version of html-webpack-plugin is upgraded aslo.

Perhaps we a conditional for the old compilation hooks. that might work.

Let me know what you think, this is my first time contributing to an open source project! :)