### PR TITLE
fix Tapable.plugin is deprecated with webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ class ConcatPlugin {
         const relativePathArrayPromise = this.getRelativePathAsync(compiler.options.context);
 
         this.filesToConcatAbsolutePromise = new Promise((resolve, reject) => {
-            compiler.resolverFactory.plugin('resolver normal', resolver => {
+            compiler.resolverFactory.hooks.resolver.for('normal').tap('WebpackConcatPlugin', resolver => {
                 resolve(relativePathArrayPromise
                     .then(relativeFilePathArray =>
                         Promise.all(relativeFilePathArray.map(relativeFilePath =>

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "webpack-concat-plugin",
-  "version": "3.0.0",
+  "name": "@penggy/webpack-concat-plugin",
+  "version": "3.0.1",
   "author": "huangxueliang",
   "description": "Webpack file concatenation.",
   "license": "ISC",
+  "private": false,
   "main": "./release.js",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
related 

#58

#68

https://github.com/hxlniada/webpack-concat-plugin/issues/46#issuecomment-374891111


